### PR TITLE
add basic javascriptless mobile menu

### DIFF
--- a/clean-blog/static/css/custom.css
+++ b/clean-blog/static/css/custom.css
@@ -7,11 +7,23 @@ a {
 }
 
 .navbar-collapse {
-  height: 0;
+  max-height: 0 !important;
+  transition: max-height 1s ease;
+  display: block;
+  visibility: visible;
 }
 
-#navigation-dropdown-visibility-checkbox-internal:checked + .navbar-collapse {
+.navbar-collapse *{
+  visibility: hidden;
+}
+
+#navigation-dropdown-visibility-checkbox-internal:checked+.navbar-collapse{
+  max-height: 340px !important; /* Magic value comes from Bootstrap */
   height: auto !important;
   display: block;
+  visibility: visible;
+}
+
+#navigation-dropdown-visibility-checkbox-internal:checked+.navbar-collapse *{
   visibility: visible;
 }

--- a/clean-blog/static/css/custom.css
+++ b/clean-blog/static/css/custom.css
@@ -1,3 +1,17 @@
 a {
     color: #0085a1;
-} 
+}
+
+#navigation-dropdown-visibility-checkbox-internal {
+  display: none;
+}
+
+.navbar-collapse {
+  height: 0;
+}
+
+#navigation-dropdown-visibility-checkbox-internal:checked + .navbar-collapse {
+  height: auto !important;
+  display: block;
+  visibility: visible;
+}

--- a/clean-blog/templates/base.html
+++ b/clean-blog/templates/base.html
@@ -84,15 +84,15 @@
         <div class="container-fluid">
             <!-- Brand and toggle get grouped for better mobile display -->
             <div class="navbar-header page-scroll">
-                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+                <label class="navbar-toggle collapsed" for="navigation-dropdown-visibility-checkbox-internal">
                     <span class="sr-only">Toggle navigation</span>
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
-                </button>
+                </label>
                 <a class="navbar-brand" href="{{ SITEURL }}/">{{ SITENAME }}</a>
             </div>
-
+            <input type="checkbox" id="navigation-dropdown-visibility-checkbox-internal">
             <!-- Collect the nav links, forms, and other content for toggling -->
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                 <ul class="nav navbar-nav navbar-right">

--- a/clean-blog/templates/base.html
+++ b/clean-blog/templates/base.html
@@ -94,7 +94,7 @@
             </div>
             <input type="checkbox" id="navigation-dropdown-visibility-checkbox-internal">
             <!-- Collect the nav links, forms, and other content for toggling -->
-            <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+            <div class="navbar-collapse" id="bs-example-navbar-collapse-1">
                 <ul class="nav navbar-nav navbar-right">
                     {% for title, link in MENUITEMS %}
                         <li><a href="{{ link }}">{{ title }}</a></li>


### PR DESCRIPTION
This PR removes the need for javascript to use the collapsable menu.
Closes #2 

It is still WiP, because having a smooth transition (like with the JS original) would be nice, although I have no clue how to archive something.