### PR TITLE
Accessibility improvements to navigation

### DIFF
--- a/clean-blog/templates/base.html
+++ b/clean-blog/templates/base.html
@@ -83,7 +83,7 @@
     <a href="#content" class="sr-only">Skip to content</a>
 
     <!-- Navigation -->
-    <nav class="navbar navbar-default navbar-custom navbar-fixed-top">
+    <nav class="navbar navbar-default navbar-custom navbar-fixed-top" role="navigation">
         <div class="container-fluid">
             <!-- Brand and toggle get grouped for better mobile display -->
             <div class="navbar-header page-scroll">
@@ -123,7 +123,7 @@
     {% block header %}{% endblock header %}
 
     <!-- Main Content -->
-    <div class="container" id="content">
+    <div class="container" id="content" role="main">
         <div class="row">
             <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
                 {% block content %}{% endblock content %}
@@ -134,14 +134,14 @@
     <hr>
 
     <!-- Footer -->
-    <footer>
+    <footer role="contentinfo">
         <div class="container">
             <div class="row">
                 <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
-                    <p class="copyright text-muted">All content <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC by SA</a> unless stated otherwise.</p>
-                    <p class="copyright text-muted">Blog powered by <a href="http://getpelican.com">Pelican</a>,
-                which takes great advantage of <a href="http://python.org">Python</a>.</p>
-                    <p class="copyright text-muted"> <a href="https://chaostreff-flensburg.de/impressum/">Impressum</a> || <a href="https://chaostreff-flensburg.de/datenschutz/">Datenschutz</a>
+                    <p class="copyright text-muted">All content <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY SA</a> unless stated otherwise.</p>
+                    <p class="copyright text-muted">Blog powered by <a href="http://getpelican.com">Pelican,</a>
+                which takes great advantage of <a href="http://python.org">Python.</a></p>
+                    <p class="copyright text-muted"> <a href="https://chaostreff-flensburg.de/impressum/">Impressum</a> <span aria-hidden="true">||</span> <a href="https://chaostreff-flensburg.de/datenschutz/">Datenschutz</a>
                 </div>
             </div>
         </div>

--- a/clean-blog/templates/base.html
+++ b/clean-blog/templates/base.html
@@ -79,6 +79,9 @@
 
 <body>
 
+    <!-- Jump to content immediately, skip navigation for screenreader users -->
+    <a href="#content" class="sr-only">Skip to content</a>
+
     <!-- Navigation -->
     <nav class="navbar navbar-default navbar-custom navbar-fixed-top">
         <div class="container-fluid">
@@ -120,7 +123,7 @@
     {% block header %}{% endblock header %}
 
     <!-- Main Content -->
-    <div class="container">
+    <div class="container" id="content">
         <div class="row">
             <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
                 {% block content %}{% endblock content %}

--- a/clean-blog/templates/base.html
+++ b/clean-blog/templates/base.html
@@ -84,13 +84,12 @@
         <div class="container-fluid">
             <!-- Brand and toggle get grouped for better mobile display -->
             <div class="navbar-header page-scroll">
-                <label class="navbar-toggle collapsed" for="navigation-dropdown-visibility-checkbox-internal">
-                    <span class="sr-only">Toggle navigation</span>
+                <a class="navbar-brand" href="{{ SITEURL }}/">{{ SITENAME }}</a>
+                <label class="navbar-toggle collapsed" for="navigation-dropdown-visibility-checkbox-internal" aria-label="Navigation toggle">
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </label>
-                <a class="navbar-brand" href="{{ SITEURL }}/">{{ SITENAME }}</a>
             </div>
             <input type="checkbox" id="navigation-dropdown-visibility-checkbox-internal">
             <!-- Collect the nav links, forms, and other content for toggling -->


### PR DESCRIPTION
This PR changes the order of the branding and the toggle so that the menu items are directly preceeded by the toggle. This will mean less confusion for screen reader users. Additionally, it no longer users `.sr-only` which has a tendency to sometimes break browser behaviour in an unwanted way. Instead, we should use `aria-label` here.

It also includes an anchor to skip to the page content immediately if screen reader users don't need the navigation when they view a page.  

To simplify nonvisual navigation even further, I have included role identifiers for the appropriate sections of the pages. This includes slight changes to the footer, essentially hiding the "||" separator away from screen reader users (it's not needed) and including punctuation within anchor tags so they are not read out separately.