### PR TITLE
CI: Initial setup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,61 @@
+---
+name: Build website
+on:
+  push: {branches: [ main ]}
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt'
+      - run: pip install -r requirements.txt
+      - run: make publish
+      - uses: actions/upload-artifact@v2
+        with:
+          name: website_pelican-build
+          path: ./public
+  deploy_production:
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    environment:
+      name: production
+      url: https://chaos.jetzt
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: website_pelican-build
+      - run: ls
+      - name: deploy
+        uses: burnett01/rsync-deployments@5.2.1
+        with:
+          switches: -avzr --delete
+          remote_path: .
+          remote_host: chaos.jetzt
+          remote_user: web-deploy
+          remote_key: ${{ secrets.DEPLOY_KEY }}
+  deploy_dev:
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    if: ${{ github.ref != 'refs/heads/master' }}
+    environment:
+      name: development
+      url: https://dev.chaos.jetzt
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: website_pelican-build
+      - name: deploy
+        uses: burnett01/rsync-deployments@5.2.1
+        with:
+          path: public/
+          switches: -avzr --delete
+          remote_path: .
+          remote_host: dev.chaos.jetzt
+          remote_user: web-deploy
+          remote_key: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
Whenever something is merged/pushed onto master, it will be deployed on the main https://chaos.jetzt page. When triggered manually, all other branches are being deployed on https://dev.chaos.jetzt.

Should be seen in conjunction with https://github.com/chaos-jetzt/chaos-jetzt-nixfiles/pull/7. The dev-deploy however, should already work.

I have created the production and development environments with their respective `DEPLOY_KEY` already for this repo in the GitHub settings.