### PR TITLE
Custom 404 + GitHub Actions fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
       - uses: actions/setup-python@v4
         with:
           python-version: '3'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,7 @@ jobs:
   deploy_production:
     runs-on: ubuntu-latest
     needs: [ build ]
+    if: github.ref == 'refs/heads/main'
     environment:
       name: production
       url: https://chaos.jetzt
@@ -42,7 +43,7 @@ jobs:
   deploy_dev:
     runs-on: ubuntu-latest
     needs: [ build ]
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: github.ref != 'refs/heads/main'
     environment:
       name: development
       url: https://dev.chaos.jetzt

--- a/content/pages/404.md
+++ b/content/pages/404.md
@@ -1,0 +1,5 @@
+Title: Nicht gefunden
+Status: hidden
+Save_as: 404.html
+
+Unter diesem Link gibt es leider (noch) nichts zu sehen. Villeicht wirst du ja in unserem [Archiv](/archives.html) fündig?


### PR DESCRIPTION
Various changes that are appear to small to create a single PR for them. The custom 404 requires https://github.com/chaos-jetzt/chaos-jetzt-nixfiles/pull/16 to be merged to gain any effect.