### PR TITLE
feat: Add rel=me tag to have a verified link on Mastodon

### DIFF
--- a/clean-blog/templates/base.html
+++ b/clean-blog/templates/base.html
@@ -90,7 +90,7 @@
             <div class="navbar-collapse" id="bs-example-navbar-collapse-1">
                 <ul class="nav navbar-nav navbar-right">
                     {% for title, link in MENUITEMS %}
-                        <li><a rel="me" href="{{ link }}">{{ title }}</a></li>
+                        <li><a href="{{ link }}">{{ title }}</a></li>
                     {% endfor %}
 
                     {% if DISPLAY_PAGES_ON_MENU %}

--- a/clean-blog/templates/base.html
+++ b/clean-blog/templates/base.html
@@ -90,7 +90,7 @@
             <div class="navbar-collapse" id="bs-example-navbar-collapse-1">
                 <ul class="nav navbar-nav navbar-right">
                     {% for title, link in MENUITEMS %}
-                        <li><a href="{{ link }}">{{ title }}</a></li>
+                        <li><a rel="me" href="{{ link }}">{{ title }}</a></li>
                     {% endfor %}
 
                     {% if DISPLAY_PAGES_ON_MENU %}

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -44,7 +44,7 @@ AUTHOR_FEED_RSS = None
 MENUITEMS = (('FAQ', '/pages/faq.html'),
              ('wiki', 'https://wiki.chaos.jetzt" target="_blank'),
              ('Code of Conduct', '/pages/coc.html'),
-             ('mastodon', 'https://chaos.social/@jetzt" target="_blank'),
+             ('mastodon', 'https://chaos.social/@jetzt" target="_blank" rel="me'),
 )
 
 LINKS = (

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -47,12 +47,6 @@ MENUITEMS = (('FAQ', '/pages/faq.html'),
              ('mastodon', 'https://chaos.social/@jetzt" target="_blank" rel="me"'),
 )
 
-LINKS = (
-    ('mastodon', 'https://chaos.social/@jetzt'),
-    #('Code of Conduct', 'https://md.ctfl.space/s/chaos.jetzt-coc')
-)
-
-
 CC_LICENSE = {
     'name': 'Creative Commons Attribution-ShareAlike',
     'version': '4.0',

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -42,9 +42,9 @@ AUTHOR_FEED_RSS = None
 
 
 MENUITEMS = (('FAQ', '/pages/faq.html'),
-             ('wiki', 'https://wiki.chaos.jetzt" target="_blank'),
-             ('Code of Conduct', '/pages/coc.html'),
-             ('mastodon', 'https://chaos.social/@jetzt" target="_blank" rel="me'),
+             ('wiki', 'https://wiki.chaos.jetzt" target="_blank"'),
+             ('Code of Conduct', '/pages/coc.html"'),
+             ('mastodon', 'https://chaos.social/@jetzt" target="_blank" rel="me"'),
 )
 
 LINKS = (


### PR DESCRIPTION
~~I admit this is a kinda hackish solution, because it adds this tag to _all_ links in the navigation bar.~~ 

It has no other bad influence: https://developer.mozilla.org/docs/Web/HTML/Attributes/rel/me

~~If anyone has a better solution that does not add it everywhere, feel free t adjust/commit.~~

Result is this:
```html
<li><a rel="me" href="https://chaos.social/@jetzt" target="_blank">mastodon</a></li>
```

**Edit:** Fixed it to only add ` rel="me"` where required:
![grafik](https://github.com/chaos-jetzt/website_pelican/assets/11966684/c1c762d8-3a38-4e3b-a574-82454f20d0e0)
