### PR TITLE
feat: Add .devcontainer file to ease working with GitHub codespaces or similar

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "Pelican Development",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.pylint",
+        "ms-vscode.makefile-tools",
+        "github.codespaces"
+      ]
+    }
+  },
+  "updateContentCommand": "pip install -r requirements.txt",
+  "postStartCommand": "make devserver",
+  "forwardPorts": [8000],
+  "containerEnv": {
+    "LOCALE": "de_DE"
+  }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ecmel.vscode-html-css",
+        "yzhang.markdown-all-in-one"
+    ]
+}


### PR DESCRIPTION
See https://containers.dev/
This is e.g. used by GitHub: https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers

You can use it in GitHub Codespaces, just go to github.dev (change the URL from GitHub.com to GitHub.dev) and it should bring up such a cloud development environment with everything preinstalled.

I used this for https://github.com/chaos-jetzt/website_pelican/pull/37 and it worked glad.

Created with credits to [ChatGPT](https://chat.openai.com/share/4404c038-ff14-446b-a081-b2c33e187486) as I had no real experience with that.
I also tried other thing slike creating a `launch.json` for VSCode there, which failed.
Anyway, you hardly need to debug your Python script hehe.